### PR TITLE
Endpoint support

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/zarr/OmeroAmazonS3ClientFactory.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/OmeroAmazonS3ClientFactory.java
@@ -36,6 +36,8 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.upplication.s3fs.AmazonS3ClientFactory;
 
+import Ice.SysLoggerI;
+
 public class OmeroAmazonS3ClientFactory extends AmazonS3ClientFactory {
 
 
@@ -117,15 +119,12 @@ public class OmeroAmazonS3ClientFactory extends AmazonS3ClientFactory {
      */
     private String getEndPointFromUri(URI uri) {
         String host = uri.getHost();
-        if (host.contains("amazonaws.com")) {
-            return ENDPOINT;
-        }
-        // Check if is an endpoint other than s3.amazonaws.com
+        // Check if is an endpoint is specified
         String[] values = host.split("\\.");
-        if (values.length > 1) {
-            return "https://" + host;
+        if (values.length == 1) {
+            throw new RuntimeException("Endpoint " + host + " not supported");
         }
-        return ENDPOINT;
+        return "https://" + host;
     }
 
     @Override

--- a/src/main/java/com/glencoesoftware/omero/zarr/OmeroAmazonS3ClientFactory.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/OmeroAmazonS3ClientFactory.java
@@ -62,7 +62,6 @@ public class OmeroAmazonS3ClientFactory extends AmazonS3ClientFactory {
         }
         boolean anonymous = Boolean.parseBoolean(
                 (String) props.get("s3fs_anonymous"));
-        anonymous = true;
         if (anonymous) {
             log.debug("Using anonymous credentials");
             return new AWSStaticCredentialsProvider(

--- a/src/main/java/com/glencoesoftware/omero/zarr/OmeroAmazonS3ClientFactory.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/OmeroAmazonS3ClientFactory.java
@@ -36,8 +36,6 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.upplication.s3fs.AmazonS3ClientFactory;
 
-import Ice.SysLoggerI;
-
 public class OmeroAmazonS3ClientFactory extends AmazonS3ClientFactory {
 
 


### PR DESCRIPTION
This PR replaces the original work done in https://github.com/glencoesoftware/omero-zarr-pixel-buffer/pull/24

* Use the endpoint to connect. The code currently uses following format s3://[endpoint]/[bucket]/[key]. The proposed change no longer assumes that the [endpoint] has the region information but it still assumes that the endpoint is provided