### PR TITLE
Add workflow to create merge build

### DIFF
--- a/.github/workflows/merge-build.yml
+++ b/.github/workflows/merge-build.yml
@@ -1,0 +1,116 @@
+name: Create merge build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  merge_all_prs_and_build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Initial checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+          
+      - name: Check if merged_prs branch exists and create if missing
+        run: |
+          if ! git ls-remote --heads origin merged_prs | grep merged_prs; then
+            echo "merged_prs branch does not exist, creating it"
+            git checkout -b merged_prs
+            git push -u origin merged_prs
+          else
+            echo "merged_prs branch exists, resetting to master"
+            git fetch origin master
+            git checkout -b temp_branch
+            git branch -D merged_prs || true
+            git checkout -b merged_prs origin/master
+            git push -f origin merged_prs
+          fi
+          
+      - name: Checkout merged_prs branch
+        uses: actions/checkout@v3
+        with:
+          ref: merged_prs
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Install GitHub CLI
+        run: |
+          sudo apt update
+          sudo apt install -y gh
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+
+      - name: Get open PR branches and numbers
+        id: prlist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh auth setup-git
+          # Get PRs and sort by creation date (oldest first) using jq
+          gh pr list --state open --json number,headRefName,createdAt > prs.json
+          jq -r 'sort_by(.createdAt) | .[] | "\(.headRefName) \(.number)"' prs.json > pr_branches.txt
+
+      - name: Merge all PRs into merged_prs
+        run: |
+          while read branch pr_number; do
+            echo "Merging PR #$pr_number ($branch)"
+            git fetch origin $branch
+            if ! git merge --no-ff --no-edit origin/$branch; then
+              echo "::error::Conflict merging PR #$pr_number ($branch)"
+              echo "❌ PR #$pr_number: Merge conflicts." >> pr_results.txt
+              git merge --abort
+            else
+              echo "::notice::Successfully merged PR #$pr_number ($branch)"
+              echo "✅ PR #$pr_number: No merge conflicts." >> pr_results.txt
+            fi
+          done < pr_branches.txt
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Run Gradle Build
+        run: ./gradlew clean build
+
+      - name: Upload build artifacts (JARs, reports)
+        uses: actions/upload-artifact@v4
+        with:
+          name: gradle-artifacts
+          path: |
+            build/libs/
+            build/reports/
+          if-no-files-found: warn
+
+      - name: Collect build result
+        run: |
+          echo "Build completed successfully. ✅" >> pr_results.txt
+
+      - name: Push merged branch back to origin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push origin merged_prs
+
+      - name: Comment on all PRs
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get the workflow run URL for viewing the run and its artifacts
+          WORKFLOW_URL="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          
+          while read branch pr_number; do
+            if grep -q "PR #$pr_number:" pr_results.txt; then
+              echo "Posting result to PR #$pr_number"
+              COMMENT=$(grep "PR #$pr_number" pr_results.txt)
+              gh pr comment $pr_number --body "$COMMENT ([Details]($WORKFLOW_URL))"
+            fi
+          done < pr_branches.txt


### PR DESCRIPTION
Adds a github workflow which creates a merge build of all open PRs. Needs to be triggered manually.
It will comment on each PR if it can be merged and provides the jars as artifacts.

![Screenshot 2025-06-27 at 13 29 06](https://github.com/user-attachments/assets/5baccf0e-a069-43c1-9c79-75077179604d)

![Screenshot 2025-06-27 at 13 29 29](https://github.com/user-attachments/assets/b46c9377-e220-495e-b4b4-bdc3aa5f19c9)

Replaces #3 which I messed up a bit...