### PR TITLE
Zarr v3 support

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelsService.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelsService.java
@@ -25,6 +25,8 @@ import dev.zarr.zarrjava.core.Array;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import ome.api.IQuery;
 import ome.conditions.LockTimeout;
@@ -53,6 +55,7 @@ public class ZarrPixelsService extends ome.io.nio.PixelsService {
 
     public static final String NGFF_ENTITY_TYPE = "com.glencoesoftware.ngff:multiscales";
     public static final long NGFF_ENTITY_ID = 3;
+    public static final long NGFF_ENTITY_ID_V2 = 4;
 
     /** Max Plane Width. */
     protected final Integer maxPlaneWidth;
@@ -128,10 +131,15 @@ public class ZarrPixelsService extends ome.io.nio.PixelsService {
      * @return the value of {@link ExternalInfo.lsid}, <code>null</code> if the object does not have
      *         an {@link ExternalInfo} with a valid {@link ExternalInfo.lsid} atttribute or if
      *         {@link ExternalInfo.entityType} is not equal to {@link NGFF_ENTITY_TYPE} or if
-     *         {@link ExternalInfo.entityId} is not equal to {@link NGFF_ENTITY_ID}.
+     *         {@link ExternalInfo.entityId} is not equal to {@link NGFF_ENTITY_ID}
+     *         or {@link NGFF_ENTITY_ID_V2}.
      */
     public String getUri(IObject object) {
-        return getUri(object, NGFF_ENTITY_TYPE, NGFF_ENTITY_ID);
+        String uri = getUri(object, NGFF_ENTITY_TYPE, NGFF_ENTITY_ID);
+        if (uri == null) {
+            uri = getUri(object, NGFF_ENTITY_TYPE, NGFF_ENTITY_ID_V2);
+        }
+        return uri;
     }
 
     /**
@@ -178,9 +186,18 @@ public class ZarrPixelsService extends ome.io.nio.PixelsService {
         }
 
         String uri = externalInfo.getLsid();
+
         if (uri == null) {
             log.debug("{}:{} missing LSID", object.getClass().getSimpleName(), object.getId());
             return null;
+        }
+
+        if (targetEntityType == NGFF_ENTITY_TYPE
+            && targetEntityId == NGFF_ENTITY_ID
+            && uri.startsWith("s3://")) {
+            String toDecode = uri.replace("s3://", "");
+            // We need to URL decode the old-style NGFF LSIDs.
+            uri = "s3://" + URLDecoder.decode(toDecode, StandardCharsets.UTF_8);
         }
         return uri;
     }

--- a/src/main/java/com/glencoesoftware/omero/zarr/ZarrStore.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/ZarrStore.java
@@ -15,8 +15,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -119,9 +117,9 @@ public class ZarrStore {
             }
             // Extract URL parameters for authentication
             Map<String, String> params = new HashMap<>();
-            // Encode to avoid java.net.URISyntaxException
-            String encodedPath = URLEncoder.encode(orgPath, StandardCharsets.UTF_8);
-            String query = (new URI(encodedPath)).getQuery();
+            // TODO: Is there a better way for parsing query parameters
+            // in the presence of URL unsafe characters?
+            String query = orgPath.substring(orgPath.lastIndexOf("?") + 1);
             if (query != null) {
                 String[] pairs = query.split("&");
                 for (String pair : pairs) {

--- a/src/main/java/com/glencoesoftware/omero/zarr/ZarrStore.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/ZarrStore.java
@@ -15,6 +15,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -89,15 +91,14 @@ public class ZarrStore {
             throw new IllegalArgumentException("Path is not a .zarr");
         }
         String pathToZarr = orgPath.substring(0, zarrIndex + 5);
-        URI uri = new URI(path);
-        if (uri.getScheme() == null || uri.getScheme().equals("file")) {
+        if (!path.contains("://") || path.startsWith("file")) {
             int sep = path.lastIndexOf(File.separator);
             String storePath = path.substring(0, sep);
             String rest = path.substring(sep + 1);
             this.name = path.substring(pathToZarr.lastIndexOf(File.separator) + 1);
             store = new FilesystemStore(storePath).resolve(rest);
             iface = FilesystemStore.class;
-        } else if (uri.getScheme().startsWith("http")) {
+        } else if (path.startsWith("http")) {
             int sep = path.lastIndexOf("/");
             String storePath = path.substring(0, sep);
             String rest = path.substring(sep + 1);
@@ -107,7 +108,7 @@ public class ZarrStore {
             }
             store = new HttpStore(storePath).resolve(rest);
             iface = HttpStore.class;
-        } else if (uri.getScheme().startsWith("s3")) {
+        } else if (path.startsWith("s3")) {
             String[] tmp = path.replaceFirst("s3://", "").replaceAll("\\?.+", "").split("/");
             final String host = tmp[0];
             final String bucket = tmp[1];
@@ -118,7 +119,9 @@ public class ZarrStore {
             }
             // Extract URL parameters for authentication
             Map<String, String> params = new HashMap<>();
-            String query = (new URI(orgPath)).getQuery();
+            // Encode to avoid java.net.URISyntaxException
+            String encodedPath = URLEncoder.encode(orgPath, StandardCharsets.UTF_8);
+            String query = (new URI(encodedPath)).getQuery();
             if (query != null) {
                 String[] pairs = query.split("&");
                 for (String pair : pairs) {
@@ -161,7 +164,8 @@ public class ZarrStore {
             store = new S3Store(client, bucket, null).resolve(rest);
             iface = S3Store.class;
         } else {
-            throw new IllegalArgumentException("Unsupported URI scheme: " + uri.getScheme());
+            throw new IllegalArgumentException("Unsupported URI scheme: "
+                    + path.subSequence(0, path.indexOf("://") + 3));
         }
         Group group = Group.open(store);
         if (group instanceof dev.zarr.zarrjava.v2.Group) {

--- a/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelsServiceTest.java
+++ b/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelsServiceTest.java
@@ -23,7 +23,11 @@ import static omero.rtypes.rstring;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import omero.ApiUsageException;
 import omero.model.ExternalInfo;
@@ -45,11 +49,31 @@ public class ZarrPixelsServiceTest {
     private String uuid = UUID.randomUUID().toString();
     private String imageUri = "/data/ngff/image.zarr";
     private String labelUri = imageUri + "/0/labels/" + uuid;
+    private String urlUnsafeBucketAndKey =
+            "data/ngff dir/image&()*?%20test.zarr?anonymous=true";
     private Image image;
     private Mask mask;
     private ome.model.IObject object;
     private static final String ENTITY_TYPE = "com.glencoesoftware.ngff:multiscales";
     private static final long ENTITY_ID = 3;
+
+    private String quoteFullPath(String path) {
+        String[] segments = path.split("/");
+        List<String> quotedSegments = new ArrayList<String>();
+        for (String s : segments) {
+            if (!s.isEmpty()) {
+                // URLEncoder.encode will % encode all the characters which cause
+                // a URISyntaxException if present in the URI constructor except for " " which is
+                // encoded as "+". Because "+" IS % encoded, we can safely assume that any
+                // remaining "+" characters were formerly spaces and replace them. Space is the
+                // ONLY character which is changed but not % encoded. See
+                // https://docs.oracle.com/javase%2F7%2Fdocs%2Fapi%2F%2F/java/net/URLEncoder.html
+                quotedSegments.add(URLEncoder.encode(s, StandardCharsets.UTF_8)
+                        .replaceAll("\\+", "%20"));
+            }
+        }
+        return String.join("/", quotedSegments);
+    }
 
     /** Initializes a ZarrPixelsService with temporary directories. */
     @Before
@@ -93,6 +117,17 @@ public class ZarrPixelsServiceTest {
         object = (ome.model.core.Image) new IceMapper().reverse(image);
         Assert.assertEquals(pixelsService.getUri(object), imageUri);
         Assert.assertEquals(pixelsService.getUri(object, ENTITY_TYPE, ENTITY_ID), imageUri);
+    }
+
+    @Test
+    public void testEncoded() throws ApiUsageException, IOException {
+        String protocolAndHost = "s3://s3.us-east-1.amazonaws.com/";
+        String encodedUnsafeUri = quoteFullPath(urlUnsafeBucketAndKey);
+        addExternalInfo(image, ENTITY_ID, ENTITY_TYPE, protocolAndHost + encodedUnsafeUri, uuid);
+        object = (ome.model.core.Image) new IceMapper().reverse(image);
+        Assert.assertEquals(pixelsService.getUri(object), protocolAndHost + urlUnsafeBucketAndKey);
+        Assert.assertEquals(pixelsService.getUri(object, ENTITY_TYPE, ENTITY_ID),
+                protocolAndHost + urlUnsafeBucketAndKey);
     }
 
     @Test


### PR DESCRIPTION
Currently, the zarr v3 work does not support URL unsafe characters in the zarr paths/URIs. With this PR, they will be supported. This was achieved by replacing use of the `URI` class to parse the path with string manipulations. In addition, some functionality was added to support both "old" and "new" styles of lsid. Previously, `s3fs` was the underlying library used to get data form S3, and it required that the S3 URI be URL encoded. The decision was made to require the lsid strings to be encoded so that `ZarrPixelsService` could just pass the `lsid` directly without any encoding/decoding necessary. However, now that we are using `zarr-java`, which is using the v2 sdk `HeadObjectRequest` and `GetObjectRequest` classes, it it now required that the S3 paths _NOT_ be URL encoded (the sdk does the encoding, so providing an encoded string results in double-encoding and a 404). With this PR, the `ZarrPixelsService` will check the `entity ID` of the object. If it's the old value and an S3 path, it will decode `getUri` will decode the path before returning it. If it's the new value, it will return the raw `lsid`. 